### PR TITLE
Add RequiredEdges and RequiredTriangles keywords

### DIFF
--- a/src/meshio/medit/_medit.py
+++ b/src/meshio/medit/_medit.py
@@ -278,6 +278,8 @@ def read_ascii_buffer(f):
             f.readline()
         elif items[0] in [
             "RequiredVertices",
+            "RequiredEdges",
+            "RequiredTriangles",
             "TangentAtVertices",
             "Tangents",
             "Ridges",


### PR DESCRIPTION
This pull request adds "RequiredEdges" and "RequiredTriangles" as keywords for meshio medit reader. This is to help with mmg remesher compatibility when remeshing while keeping initial mesh periodicity, as mmg needs those keywords to know which elements not to remesh.

